### PR TITLE
Fix image retrieval width parameter in JLCustomClockApplet

### DIFF
--- a/src/JLCustomClockApplet.lua
+++ b/src/JLCustomClockApplet.lua
@@ -3043,7 +3043,7 @@ function _updateSDTWeatherMapIcon(self,widget,id,item)
 					if url then
 						self.configItems[id].url = url
 						self.referenceimages[self.mode.."item"..id] = id
-						self:_retrieveImage(url,self.mode.."item"..id,_getString(item.allowproxy,"true"),"true",_getNumber(width,nil),_getNumber(item.height,nil),_getNumber(item.clipx,nil),_getNumber(item.clipy,nil),_getNumber(item.clipwidth,nil),_getNumber(item.clipheight,nil))
+						self:_retrieveImage(url,self.mode.."item"..id,_getString(item.allowproxy,"true"),"true",_getNumber(item.width,nil),_getNumber(item.height,nil),_getNumber(item.clipx,nil),_getNumber(item.clipy,nil),_getNumber(item.clipwidth,nil),_getNumber(item.clipheight,nil))
 					end
 				end
 			end,


### PR DESCRIPTION
width is not defined in that scope, we need to use _getNumber(item.width,nil)